### PR TITLE
Add Tests

### DIFF
--- a/src/code_flow_test.ts
+++ b/src/code_flow_test.ts
@@ -1,0 +1,804 @@
+// deno-lint-ignore-file no-explicit-any
+import {
+  assertEquals,
+  assertMatch,
+  assertNotMatch,
+  assertThrowsAsync,
+} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+import { spy, stub } from "https://deno.land/x/mock@v0.7.0/mod.ts";
+
+import { OAuth2Client, OAuth2ClientConfig } from "./oauth2_client.ts";
+import type {
+  AccessTokenResponse,
+  GetTokenOptions,
+  Tokens,
+} from "./code_flow.ts";
+import { AuthError, AuthServerResponseError } from "./errors.ts";
+
+//#region CodeFlow.getAuthorizationUri successful paths
+
+Deno.test("CodeFlow.getAuthorizationUri works without additional options", () => {
+  assertMatchesUrl(
+    getOAuth2Client().code.getAuthorizationUri(),
+    "https://auth.server/auth?response_type=code&client_id=clientId",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri works when passing a single scope", () => {
+  assertMatchesUrl(
+    getOAuth2Client().code.getAuthorizationUri({
+      scope: "singleScope",
+    }),
+    "https://auth.server/auth?response_type=code&client_id=clientId&scope=singleScope",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri works when passing multiple scopes", () => {
+  assertMatchesUrl(
+    getOAuth2Client().code.getAuthorizationUri({
+      scope: ["multiple", "scopes"],
+    }),
+    "https://auth.server/auth?response_type=code&client_id=clientId&scope=multiple+scopes",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri works when passing a state parameter", () => {
+  assertMatchesUrl(
+    getOAuth2Client().code.getAuthorizationUri({
+      state: "someState",
+    }),
+    "https://auth.server/auth?response_type=code&client_id=clientId&state=someState",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri works with redirectUri", () => {
+  assertMatchesUrl(
+    getOAuth2Client({
+      redirectUri: "https://example.app/redirect",
+    }).code.getAuthorizationUri(),
+    "https://auth.server/auth?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fexample.app%2Fredirect",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri works with redirectUri and a single scope", () => {
+  assertMatchesUrl(
+    getOAuth2Client({
+      redirectUri: "https://example.app/redirect",
+    }).code.getAuthorizationUri({
+      scope: "singleScope",
+    }),
+    "https://auth.server/auth?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fexample.app%2Fredirect&scope=singleScope",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri works with redirectUri and multiple scopes", () => {
+  assertMatchesUrl(
+    getOAuth2Client({
+      redirectUri: "https://example.app/redirect",
+    }).code.getAuthorizationUri({
+      scope: ["multiple", "scopes"],
+    }),
+    "https://auth.server/auth?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fexample.app%2Fredirect&scope=multiple+scopes",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri uses default scopes if no scope was specified", () => {
+  assertMatchesUrl(
+    getOAuth2Client({
+      defaults: { scope: ["default", "scopes"] },
+    }).code.getAuthorizationUri(),
+    "https://auth.server/auth?response_type=code&client_id=clientId&scope=default+scopes",
+  );
+});
+
+Deno.test("CodeFlow.getAuthorizationUri uses specified scopes over default scopes", () => {
+  assertMatchesUrl(
+    getOAuth2Client({
+      defaults: { scope: ["default", "scopes"] },
+    }).code.getAuthorizationUri({
+      scope: "notDefault",
+    }),
+    "https://auth.server/auth?response_type=code&client_id=clientId&scope=notDefault",
+  );
+});
+
+//#endregion
+
+//#region TODO: CodeFlow.getAuthorization error paths
+
+//#endregion
+
+//#region CodeFlow.getToken
+//#region CodeFlow.getToken error paths
+
+Deno.test("CodeFlow.getToken throws if the received redirectUri does not match the configured one", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client({
+        redirectUri: "https://example.com/redirect",
+      }).code.getToken(
+        buildAccessTokenCallback("https://example.com/invalid-redirect", {}),
+      ),
+    TypeError,
+    "Redirect path should match configured path",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the callbackUri does not contain any parameters", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback("https://example.com/redirect", {}),
+      ),
+    TypeError,
+    "URI does not contain callback parameters",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the callbackUri contains an error parameter", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          { error: "invalid_request" },
+        ),
+      ),
+    AuthError,
+    "invalid_request",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the callbackUri contains the error, error_description and error_uri parameters and adds them to the error object", async () => {
+  const error = await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          {
+            error: "invalid_request",
+            error_description: "Error description",
+            error_uri: "error://uri",
+          },
+        ),
+      ),
+    AuthError,
+    "Error description",
+  ) as AuthError;
+  assertEquals(error.error, "invalid_request");
+  assertEquals(error.errorDescription, "Error description");
+  assertEquals(error.errorUri, "error://uri");
+});
+
+Deno.test("CodeFlow.getToken throws if the callbackUri doesn't contain a code", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          // state parameter has to be set or we'll get "URI does not contain callback parameters" instead
+          { state: "" },
+        ),
+      ),
+    TypeError,
+    "Missing code, unable to request token",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if it didn't receive a state and the state validator fails", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          { code: "code" },
+        ),
+        { stateValidator: () => false },
+      ),
+    TypeError,
+    "Missing state",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if it didn't receive a state but a state was expected", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          { code: "code" },
+        ),
+        { state: "expected_state" },
+      ),
+    TypeError,
+    "Missing state",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if it received a state that does not match the given state parameter", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          { code: "code", state: "invalid_state" },
+        ),
+        { state: "expected_state" },
+      ),
+    TypeError,
+    "Invalid state: invalid_state",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the stateValidator returns false", async () => {
+  await assertThrowsAsync(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback(
+          "https://example.com/redirect",
+          { code: "code", state: "invalid_state" },
+        ),
+        { stateValidator: () => false },
+      ),
+    TypeError,
+    "Invalid state: invalid_state",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server responded with a Content-Type other than application/json", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          status: 200,
+          headers: {
+            "Content-Type": "x-www-form-urlencoded",
+          },
+          body: "",
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: Response is not JSON encoded",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server responded with a correctly formatted error", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          status: 401,
+          body: { error: "invalid_client" },
+        },
+      }),
+    AuthError,
+    "invalid_client",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server responded with a 4xx or 5xx and the body doesn't contain an error parameter", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          status: 401,
+          body: {
+            no_error_property: true,
+          } as any,
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: Server returned 401 and no error description was given",
+  );
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          status: 503,
+          body: {} as any,
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: Server returned 503 and no error description was given",
+  );
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          status: 418,
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: Server returned 418 and no error description was given",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server's response is not a JSON object", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: { body: '""' },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: body is not a JSON object",
+  );
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: { body: "1234" },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: body is not a JSON object",
+  );
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: { body: "null" },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: body is not a JSON object",
+  );
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: { body: `["array values?!!"]` },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: body is not a JSON object",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server's response does not contain a token_type", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          body: { access_token: "at" },
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: missing token_type",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server's response does not contain an access_token", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          body: { token_type: "tt" },
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: missing access_token",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server response's access_token is not a string", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          body: {
+            access_token: 1234 as any,
+            token_type: "tt",
+          },
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: access_token is not a string",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server response's refresh_token property is not a string", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          body: {
+            access_token: "at",
+            token_type: "tt",
+            refresh_token: 123 as any,
+          },
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: refresh_token is not a string",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server response's expires_in property is not a number", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          body: {
+            access_token: "at",
+            token_type: "tt",
+            expires_in: { this: "is illegal" } as any,
+          },
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: expires_in is not a number",
+  );
+});
+
+Deno.test("CodeFlow.getToken throws if the server response's scope property is not a string", async () => {
+  await assertThrowsAsync(
+    () =>
+      mockAccessTokenResponse_({
+        callbackUrl: { code: "authCode" },
+        tokenResponse: {
+          body: {
+            access_token: "at",
+            token_type: "tt",
+            scope: ["scope1", "scope2"] as any,
+          },
+        },
+      }),
+    AuthServerResponseError,
+    "Invalid server response: scope is not a string",
+  );
+});
+
+//#endregion
+
+//#region CodeFlow.getToken successful paths
+
+Deno.test("CodeFlow.getToken parses the minimal token response correctly", async () => {
+  const r = await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode" },
+    tokenResponse: {
+      body: {
+        access_token: "accessToken",
+        token_type: "tokenType",
+      },
+    },
+  });
+  assertEquals(r.result, {
+    accessToken: "accessToken",
+    tokenType: "tokenType",
+  });
+});
+
+Deno.test("CodeFlow.getToken parses the full token response correctly", async () => {
+  const r = await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode" },
+    tokenResponse: {
+      body: {
+        access_token: "accessToken",
+        token_type: "tokenType",
+        refresh_token: "refreshToken",
+        expires_in: 3600,
+        scope: "multiple scopes",
+      },
+    },
+  });
+  assertEquals(r.result, {
+    accessToken: "accessToken",
+    tokenType: "tokenType",
+    refreshToken: "refreshToken",
+    expiresIn: 3600,
+    scope: ["multiple", "scopes"],
+  });
+});
+
+Deno.test("CodeFlow.getToken doesn't throw if it didn't receive a state but the state validator returns true", async () => {
+  await mockAccessTokenResponse_({
+    callbackUrl: { code: "code" },
+    callParameters: { stateValidator: () => true },
+  });
+});
+
+Deno.test("CodeFlow.getToken builds a correct request to the token endpoint by default", async () => {
+  const r = await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode" },
+  });
+  assertEquals(r.request.url, "https://auth.server/token");
+  const body = await r.request.formData();
+  assertEquals(body.get("grant_type"), "authorization_code");
+  assertEquals(body.get("code"), "authCode");
+  assertEquals(body.get("redirect_uri"), null);
+  assertEquals(body.get("client_id"), "clientId");
+  assertEquals(
+    r.request.headers.get("Content-Type"),
+    "application/x-www-form-urlencoded",
+  );
+});
+
+Deno.test("CodeFlow.getToken correctly adds the redirectUri to the token request if specified", async () => {
+  const r = await mockAccessTokenResponse_({
+    clientConfig: {
+      redirectUri: "http://some.redirect/uri",
+    },
+    callbackUrl: { code: "authCode", base: "http://some.redirect/uri" },
+  });
+  assertEquals(
+    (await r.request.formData()).get("redirect_uri"),
+    "http://some.redirect/uri",
+  );
+});
+
+Deno.test("CodeFlow.getToken sends the clientId as form parameter if no clientSecret is set", async () => {
+  const r = await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode" },
+  });
+  assertEquals(
+    (await r.request.formData()).get("client_id"),
+    "clientId",
+  );
+  assertEquals(r.request.headers.get("Authorization"), null);
+});
+
+Deno.test("CodeFlow.getToken sends the correct Authorization header if the clientSecret is set", async () => {
+  const r = await mockAccessTokenResponse_({
+    clientConfig: { clientSecret: "super-secret" },
+    callbackUrl: { code: "authCode" },
+  });
+  assertEquals(
+    r.request.headers.get("Authorization"),
+    "Basic Y2xpZW50SWQ6c3VwZXItc2VjcmV0",
+  );
+  assertEquals((await r.request.formData()).get("client_id"), null);
+});
+
+Deno.test("CodeFlow.getToken uses the default request options", async () => {
+  const r = await mockAccessTokenResponse_({
+    clientConfig: {
+      defaults: {
+        requestOptions: {
+          headers: {
+            "User-Agent": "Custom User Agent",
+            "Content-Type": "application/json",
+          },
+          params: { "custom-param": "value" },
+        },
+      },
+    },
+    callbackUrl: { code: "authCode" },
+  });
+  assertEquals(r.request.headers.get("Content-Type"), "application/json");
+  assertEquals(r.request.headers.get("User-Agent"), "Custom User Agent");
+  assertMatch(await r.request.text(), /.*custom-param=value.*/);
+});
+
+Deno.test("CodeFlow.getToken uses the passed request options over the default options", async () => {
+  const r = await mockAccessTokenResponse_({
+    clientConfig: {
+      defaults: {
+        requestOptions: {
+          headers: {
+            "User-Agent": "Custom User Agent",
+            "Content-Type": "application/json",
+          },
+          params: { "custom-param": "value" },
+        },
+      },
+    },
+    callParameters: {
+      requestOptions: {
+        headers: { "Content-Type": "text/plain" },
+        params: { "custom-param": "other_value" },
+      },
+    },
+    callbackUrl: { code: "authCode" },
+  });
+  assertEquals(r.request.headers.get("Content-Type"), "text/plain");
+  assertEquals(r.request.headers.get("User-Agent"), "Custom User Agent");
+  assertMatch(await r.request.text(), /.*custom-param=other_value.*/);
+  assertNotMatch(await r.request.text(), /.*custom-param=value.*/);
+});
+
+Deno.test("CodeFlow.getToken uses the default state validator if no state or validator was given", async () => {
+  const defaultValidator = spy(() => true);
+
+  await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode", state: "some_state" },
+    clientConfig: {
+      defaults: { stateValidator: defaultValidator },
+    },
+  });
+
+  assertEquals(
+    defaultValidator.calls,
+    [{ args: ["some_state"], returned: true }],
+  );
+});
+
+Deno.test("CodeFlow.getToken uses the passed state validator over the default validator", async () => {
+  const defaultValidator = spy(() => true);
+  const validator = spy(() => true);
+
+  await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode", state: "some_state" },
+    clientConfig: {
+      defaults: { stateValidator: defaultValidator },
+    },
+    callParameters: { stateValidator: validator },
+  });
+
+  assertEquals(defaultValidator.calls, []);
+  assertEquals(validator.calls, [{ args: ["some_state"], returned: true }]);
+});
+
+Deno.test("CodeFlow.getToken uses the passed state validator over the passed state", async () => {
+  const defaultValidator = spy(() => true);
+  const validator = spy(() => true);
+
+  await mockAccessTokenResponse_({
+    callbackUrl: { code: "authCode", state: "some_state" },
+    clientConfig: {
+      defaults: { stateValidator: defaultValidator },
+    },
+    callParameters: { stateValidator: validator, state: "other_state" },
+  });
+
+  assertEquals(defaultValidator.calls, []);
+  assertEquals(validator.calls, [{ args: ["some_state"], returned: true }]);
+});
+
+//#endregion
+//#endregion
+
+//#region Utility test functions
+
+function getOAuth2Client(overrideConfig: Partial<OAuth2ClientConfig> = {}) {
+  return new OAuth2Client({
+    clientId: "clientId",
+    authorizationEndpointUri: "https://auth.server/auth",
+    accessTokenUri: "https://auth.server/token",
+    ...overrideConfig,
+  });
+}
+
+function assertMatchesUrl(test: URL, expectedUrl: string | URL): void {
+  const expected = expectedUrl instanceof URL
+    ? expectedUrl
+    : new URL(expectedUrl);
+
+  assertEquals(test.origin, expected.origin);
+  assertEquals(test.pathname, expected.pathname);
+  assertEquals(test.hash, expected.hash);
+
+  const testParams = [...test.searchParams.entries()].sort(([a], [b]) =>
+    a > b ? 1 : a < b ? -1 : 0
+  );
+  const expectedParams = [...expected.searchParams.entries()].sort(([a], [b]) =>
+    a > b ? 1 : a < b ? -1 : 0
+  );
+  assertEquals(testParams, expectedParams);
+}
+
+interface AccessTokenErrorResponse {
+  error: string;
+  error_description?: string;
+  error_uri?: string;
+}
+
+interface MockAccessTokenResponse {
+  status?: number;
+  headers?: { [key: string]: string };
+  body?: Partial<AccessTokenResponse | AccessTokenErrorResponse> | string;
+}
+
+interface MockAccessTokenResponseResult {
+  request: Request;
+  result: Tokens;
+}
+
+async function mockAccessTokenResponse(
+  request: () => Promise<Tokens>,
+  tokenResponse: MockAccessTokenResponse = {},
+): Promise<MockAccessTokenResponseResult> {
+  const fetchStub = stub(window, "fetch");
+  try {
+    const body = typeof tokenResponse.body === "string"
+      ? tokenResponse.body
+      : JSON.stringify(tokenResponse.body);
+
+    const headers = new Headers(
+      tokenResponse.headers || {
+        "Content-Type": "application/json",
+      },
+    );
+
+    const status = tokenResponse.status || 200;
+
+    fetchStub.returns = [
+      Promise.resolve(new Response(body, { headers, status })),
+    ];
+
+    const result = await request();
+
+    const performedRequest = fetchStub.calls[0].args[0] as Request;
+
+    return { request: performedRequest, result };
+  } finally {
+    fetchStub.restore();
+  }
+}
+
+async function mockAccessTokenResponse_(
+  options: {
+    clientConfig?: Partial<OAuth2ClientConfig>;
+    callParameters?: Partial<GetTokenOptions>;
+    callbackUrl: (AccessTokenCallbackSuccess | AccessTokenCallbackError) & {
+      base?: string;
+    };
+    tokenResponse?: MockAccessTokenResponse;
+  },
+): Promise<MockAccessTokenResponseResult> {
+  const callbackUrl = buildAccessTokenCallback(
+    options.callbackUrl.base ?? "https://example.com",
+    options.callbackUrl,
+  );
+
+  const fetchStub = stub(window, "fetch");
+  try {
+    const tokenResponse = options.tokenResponse ??
+      { body: { access_token: "at", token_type: "tt" } };
+
+    const body = typeof tokenResponse.body === "string"
+      ? tokenResponse.body
+      : JSON.stringify(tokenResponse.body);
+
+    const headers = new Headers(
+      tokenResponse.headers ?? { "Content-Type": "application/json" },
+    );
+
+    const status = tokenResponse.status ?? 200;
+
+    fetchStub.returns = [
+      Promise.resolve(new Response(body, { headers, status })),
+    ];
+
+    const result = await getOAuth2Client(options.clientConfig).code.getToken(
+      callbackUrl,
+      options.callParameters,
+    );
+
+    const request = fetchStub.calls[0].args[0] as Request;
+
+    return { request, result };
+  } finally {
+    fetchStub.restore();
+  }
+}
+
+interface AccessTokenCallbackSuccess {
+  code?: string;
+  state?: string;
+}
+interface AccessTokenCallbackError {
+  error?: string;
+  error_description?: string;
+  error_uri?: string;
+  state?: string;
+}
+
+function buildAccessTokenCallback(
+  base: string,
+  options: AccessTokenCallbackSuccess | AccessTokenCallbackError,
+): URL {
+  return new URL(
+    `?${new URLSearchParams(options as Record<string, string>)}`,
+    base,
+  );
+}
+
+//#endregion

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,8 +51,8 @@ export class AuthError extends Error {
 export class AuthServerResponseError extends Error {
   public readonly response: Response;
 
-  constructor(response: Response) {
-    super("Invalid server response");
+  constructor(description: string, response: Response) {
+    super(`Invalid server response: ${description}`);
     this.response = response;
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,7 +23,7 @@ export class AuthError extends Error {
   public static fromURLSearchParams(params: URLSearchParams) {
     const error = params.get("error");
     if (error === null) {
-      throw new TypeError("error must be set");
+      throw new TypeError("error URL parameter must be set");
     }
     const response: ErrorResponseParams = {
       error: params.get("error") as string,

--- a/src/errors_test.ts
+++ b/src/errors_test.ts
@@ -1,0 +1,108 @@
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+import { AuthError, AuthServerResponseError } from "./errors.ts";
+
+Deno.test("AuthError constructor works", () => {
+  const fullError = new AuthError({
+    error: "invalid_request",
+    error_description: "test description",
+    error_uri: "error://uri",
+    state: "some state",
+  });
+  assertEquals(fullError.message, "test description");
+  assertEquals(fullError.error, "invalid_request");
+  assertEquals(fullError.errorDescription, "test description");
+  assertEquals(fullError.errorUri, "error://uri");
+  assertEquals(fullError.state, "some state");
+
+  const noDescription = new AuthError({
+    error: "test error",
+  });
+  assertEquals(noDescription.message, "test error");
+});
+
+Deno.test("AuthError.fromURLSearchParams, URL without error parameter throws error", () => {
+  assertThrows(
+    () => {
+      AuthError.fromURLSearchParams(new URLSearchParams());
+    },
+    TypeError,
+    "error URL parameter must be set",
+  );
+});
+
+Deno.test("AuthError.fromURLSearchParams works when only the error parameter is set", () => {
+  const onlyError = AuthError.fromURLSearchParams(
+    new URLSearchParams({
+      error: "test error",
+    }),
+  );
+  assertEquals(onlyError.error, "test error");
+  assertEquals(onlyError.errorDescription, undefined);
+  assertEquals(onlyError.errorUri, undefined);
+  assertEquals(onlyError.state, undefined);
+  assertEquals(onlyError.message, "test error");
+});
+
+Deno.test("AuthError.fromURLSearchParams works when error and error_description are set", () => {
+  const withDescription = AuthError.fromURLSearchParams(
+    new URLSearchParams({
+      error: "test error",
+      error_description: "description",
+    }),
+  );
+  assertEquals(withDescription.errorDescription, "description");
+  assertEquals(withDescription.message, "description");
+});
+
+Deno.test("AuthError.fromURLSearchParams works when error and error_uri are set", () => {
+  const withErrorUri = AuthError.fromURLSearchParams(
+    new URLSearchParams({
+      error: "test error",
+      error_uri: "error://uri",
+    }),
+  );
+  assertEquals(withErrorUri.errorUri, "error://uri");
+  assertEquals(withErrorUri.message, "test error");
+});
+
+Deno.test("AuthError.fromURLSearchParams works when error and state are set", () => {
+  const withState = AuthError.fromURLSearchParams(
+    new URLSearchParams({
+      error: "test error",
+      state: "some state",
+    }),
+  );
+  assertEquals(withState.state, "some state");
+  assertEquals(withState.message, "test error");
+});
+
+Deno.test("AuthError.fromURLSearchParams works when error, error_description, error_uri and state are set", () => {
+  const fullError = AuthError.fromURLSearchParams(
+    new URLSearchParams({
+      error: "invalid_request",
+      error_description: "test description",
+      error_uri: "error://uri",
+      state: "some state",
+    }),
+  );
+  assertEquals(fullError.message, "test description");
+  assertEquals(fullError.error, "invalid_request");
+  assertEquals(fullError.errorDescription, "test description");
+  assertEquals(fullError.errorUri, "error://uri");
+  assertEquals(fullError.state, "some state");
+});
+
+Deno.test("AuthServerResponseError constructor works", () => {
+  const response = new Response("body", {
+    headers: { "Test-Header": "is set" },
+    status: 418,
+    statusText: "I'm a teapot",
+  });
+  const error = new AuthServerResponseError(response);
+
+  assertEquals(error.message, "Invalid server response");
+  assertEquals(error.response, response);
+});

--- a/src/errors_test.ts
+++ b/src/errors_test.ts
@@ -101,8 +101,8 @@ Deno.test("AuthServerResponseError constructor works", () => {
     status: 418,
     statusText: "I'm a teapot",
   });
-  const error = new AuthServerResponseError(response);
+  const error = new AuthServerResponseError("description", response);
 
-  assertEquals(error.message, "Invalid server response");
+  assertEquals(error.message, "Invalid server response: description");
   assertEquals(error.response, response);
 });

--- a/src/oauth2_client.ts
+++ b/src/oauth2_client.ts
@@ -14,7 +14,7 @@ export interface OAuth2ClientConfig {
   defaults?: {
     requestOptions?: RequestOptions;
     scope?: string | string[];
-    stateValidator?: (state: string) => boolean;
+    stateValidator?: (state: string | null) => boolean;
   };
 }
 

--- a/src/oauth2_client_test.ts
+++ b/src/oauth2_client_test.ts
@@ -1,0 +1,13 @@
+import { assert } from "https://deno.land/std@0.71.0/testing/asserts.ts";
+
+import { OAuth2Client } from "./oauth2_client.ts";
+import { CodeFlow } from "./code_flow.ts";
+
+Deno.test("OAuth2Client.code is created", () => {
+  const client = new OAuth2Client({
+    accessTokenUri: "",
+    authorizationEndpointUri: "",
+    clientId: "",
+  });
+  assert(client.code instanceof CodeFlow);
+});


### PR DESCRIPTION
Adds tests and bumps the code coverage up to 100%.

`deno test --coverage --unstable` still reports three untested lines, but that appears to be a bug in either the coverage reporter or the sourcemap generator, as those lines cannot *not* be covered:

```
  40 |         if (params.has("error")) {
 101 |         if (!response.ok) {
 122 |         if (body.refresh_token !== undefined &&
```

First, those lines are completely off.
The actual contents of those lines are:
```
  40 |     if (typeof this.client.config.redirectUri === "string") {
 101 |       throw new TypeError("Missing code, unable to request token");
 122 |
 ^^^ line 122 is literally empty
```

The lines of the reported snippets are actually on lines 95, 169 and the third one does not even exist like this in the code, as it is actually split over a few lines:
```
 203 |     if (
 204 |       body.refresh_token !== undefined &&
 205 |       typeof body.refresh_token !== "string"
 206 |     ) {
```

Anyway, when modifying any of those statement's control flows, tests fail, so I can assume those lines are actually relevant and covered by the tests failing in those scenarios.

Close #1 