### PR TITLE
fix: nullish syntax error

### DIFF
--- a/src/authorization_code_grant.ts
+++ b/src/authorization_code_grant.ts
@@ -130,8 +130,8 @@ export class AuthorizationCodeGrant extends OAuth2GrantBase {
     }
 
     const state = params.get("state");
-    const stateValidator = options.stateValidator ??
-      (options.state && ((s) => s === options.state)) ??
+    const stateValidator = options.stateValidator ||
+      (options.state && ((s) => s === options.state)) ||
       this.client.config.defaults?.stateValidator;
 
     if (stateValidator && !stateValidator(state)) {


### PR DESCRIPTION
After bundeling this package with `deno bundle`, the compiler throws a syntax error because of a combination of a nullish coalescing operator (`??`) and a AND operator (`&&`), which is [prohibited](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator#no_chaining_with_and_or_or_operators) .
This PR replaces the `??` with `||`. Another alternative would be the following snippet:
```ts
let stateValidator: (((s: string | null) => boolean) | undefined | "") =
  options.stateValidator;
if (!stateValidator) {
  stateValidator = (options.state && ((s: string | null) =>
    s === options.state));
}
if (!stateValidator) {
  stateValidator = this.client.config.defaults?.stateValidator;
}
```
But I think the current version should work fine.