### PR TITLE
Handle non standard error response

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,5 @@
+import { ResponseWithParsedBody } from './types.ts';
+
 interface ErrorResponseParams {
   error: string;
   "error_description"?: string;
@@ -58,9 +60,9 @@ export class AuthorizationResponseError extends Error {
 
 /** Error originating from the token response. */
 export class TokenResponseError extends Error {
-  public readonly response: Response;
+  public readonly response: ResponseWithParsedBody;
 
-  constructor(description: string, response: Response) {
+  constructor(description: string, response: ResponseWithParsedBody) {
     super(`Invalid token response: ${description}`);
     this.response = response;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,3 +47,8 @@ export interface Tokens {
    */
   scope?: string[];
 }
+
+export interface ResponseWithParsedBody extends Response {
+  // deno-lint-ignore no-explicit-any
+  parsedBody?: any;
+}


### PR DESCRIPTION
I was using this library to integrate with Twitch OAuth, and I ran into an issue where the Twitch Token API response was non standard and I had no way to debug the response body (the response.body property was already read and could not be cloned). This PR attaches the parsed body to the response object for easier debugging.

BTW for anyone else that comes across this error integrating Twitch OAuth, the fix was to include the `clientId` and `clientSecret` in the body of the token request (again, another non standard thing the twitch API is asking for):

```js
strategy.code.getToken('some-url-here?code=code-value-here&scope=', {
  requestOptions: {
    body: {
      // twitch doesn't seem to support RFC6749..., so add the client_id and client_secret to the body
      client_id: "value-here",
      client_secret: "value-here",
    }
  }
});
```