### PR TITLE
v1.0.0 - PKCE by default, interface cleanups and dependency/CI upgrades

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           deno-version: ${{ matrix.deno }} # tests across multiple Deno versions
 
       - name: Run Tests
-        run: deno test -A --coverage=cov_profile --unstable
+        run: deno test --coverage=cov_profile
 
       - name: Print Coverage
         run: deno coverage cov_profile
@@ -50,7 +50,7 @@ jobs:
           deno-version: ${{ matrix.deno }}
 
       - name: Run lint
-        run: deno lint --unstable
+        run: deno lint
 
   validateBundle:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        deno: ["v1.x", "nightly"]
+        deno: ["v1.x", "canary"]
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Deno
-        uses: denolib/setup-deno@master
+        uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno }} # tests across multiple Deno versions
 
@@ -37,7 +37,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        deno: ["v1.x", "nightly"]
+        deno: ["v1.x", "canary"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Deno
-        uses: denolib/setup-deno@master
+        uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno }}
 
@@ -55,7 +55,7 @@ jobs:
   validateBundle:
     strategy:
       matrix:
-        deno: ["v1.x", "nightly"]
+        deno: ["v1.x", "canary"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Deno
-        uses: denolib/setup-deno@master
+        uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno }}
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ Currently supported OAuth 2.0 grants:
 ### GitHub API example using [oak](https://deno.land/x/oak)
 
 ```ts
-import { Application, Router } from "https://deno.land/x/oak@v6.3.0/mod.ts";
+import { Application, Router } from "https://deno.land/x/oak@v11.1.0/mod.ts";
+import { Session } from "https://deno.land/x/oak_sessions@v4.0.5/mod.ts";
 import { OAuth2Client } from "https://deno.land/x/oauth2_client/mod.ts";
 
 const oauth2Client = new OAuth2Client({
-  clientId: "<your client id>",
-  clientSecret: "<your client secret>",
+  clientId: Deno.env.get("CLIENT_ID")!,
+  clientSecret: Deno.env.get("CLIENT_SECRET")!,
   authorizationEndpointUri: "https://github.com/login/oauth/authorize",
   tokenUri: "https://github.com/login/oauth/access_token",
   redirectUri: "http://localhost:8000/oauth2/callback",
@@ -36,15 +37,32 @@ const oauth2Client = new OAuth2Client({
   },
 });
 
-const router = new Router();
-router.get("/login", (ctx) => {
-  ctx.response.redirect(
-    oauth2Client.code.getAuthorizationUri(),
-  );
+type AppState = {
+  session: Session;
+};
+
+const router = new Router<AppState>();
+router.get("/login", async (ctx) => {
+  // Construct the URL for the authorization redirect and get a PKCE codeVerifier
+  const { uri, codeVerifier } = await oauth2Client.code.getAuthorizationUri();
+
+  // Store both the state and codeVerifier in the user session
+  ctx.state.session.flash("codeVerifier", codeVerifier);
+
+  // Redirect the user to the authorization endpoint
+  ctx.response.redirect(uri);
 });
 router.get("/oauth2/callback", async (ctx) => {
+  // Make sure the codeVerifier is present for the user's session
+  const codeVerifier = ctx.state.session.get("codeVerifier");
+  if (typeof codeVerifier !== "string") {
+    throw new Error("invalid codeVerifier");
+  }
+
   // Exchange the authorization code for an access token
-  const tokens = await oauth2Client.code.getToken(ctx.request.url);
+  const tokens = await oauth2Client.code.getToken(ctx.request.url, {
+    codeVerifier,
+  });
 
   // Use the access token to make an authenticated API request
   const userResponse = await fetch("https://api.github.com/user", {
@@ -57,7 +75,8 @@ router.get("/oauth2/callback", async (ctx) => {
   ctx.response.body = `Hello, ${login}!`;
 });
 
-const app = new Application();
+const app = new Application<AppState>();
+app.use(Session.initMiddleware());
 app.use(router.allowedMethods(), router.routes());
 
 await app.listen({ port: 8000 });

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Inspired by [js-client-oauth2](https://github.com/mulesoft/js-client-oauth2/).
 
 This module tries not to make assumptions on your use-cases.
 As such, it
-- has no external dependencies (not even Deno's standard library)
+- has no external dependencies outside of Deno's standard library
 - can be used with Deno's [http module](https://deno.land/std@0.71.0/http) or any other library for handling http requests, like [oak](https://deno.land/x/oak)
 - only implements OAuth 2.0 grants, letting you take care of storing and retrieving sessions, managing state parameters, etc.
 
@@ -88,3 +88,36 @@ await app.listen({ port: 8000 });
 ### More Examples
 
 For more examples, check out the examples directory.
+
+## Migration
+
+### `v0.*.*` -> `v1.*.*`
+
+With `v1.0.0`:
+- we introduced PKCE by default for the Authorization Code Grant
+- enabled `stateValidator` callbacks to return a Promise, to allow for e.g. accessing a database
+- cleaned up interface names to prevent name clashes between e.g. the `AuthorizationCodeGrant` and `ImplicitGrant` option objects.
+
+#### `AuthorizationCodeGrant`
+
+- The `GetUriOptions` interface was renamed to `AuthorizationUriOptions`
+- `getAuthorizationUri(...)` now always returns a `Promise<{ uri: URL }>` instead of a plain `URL`.
+    - when using PKCE (which is now the default), `getAuthorizationUri(...)` returns an object containing both an URI and the `codeVerifier` that you'll have to pass to the `getToken(...)` call inside the OAuth 2.0 redirection URI handler. Check out the examples on how to achieve that by using session cookies.
+    - while you should always use PKCE if possible, there are still OAuth 2.0 servers that don't support it. To opt out of PKCE, pass `{ disablePkce: true }` to `getAuthorizationUri`.
+
+#### `ClientCredentialsGrant`
+
+- The `GetClientCredentialsTokenOptions` interface was renamed to `ClientCredentialsTokenOptions`
+
+#### `ImplicitGrant`
+
+- The `GetUriOptions` interface was renamed to `ImplicitUriOptions`
+- The `GetTokenOptions` interface was renamed to `ImplicitTokenOptions`
+
+#### `ResourceOwnerPasswordCredentialsGrant`
+
+- The `GetROPCTokenOptions` interface was renamed to `ResourceOwnerPasswordCredentialsTokenOptions`
+
+#### `RefreshTokenGrant`
+
+- No changes necessary

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ As such, it
 
 Currently supported OAuth 2.0 grants:
 - [Authorization Code Grant (for clients with and without client secrets)](https://www.rfc-editor.org/rfc/rfc6749#section-4.1)
+    - Out of the box support for [Proof Key for Code Exchange (PKCE)](https://www.rfc-editor.org/rfc/rfc7636)
 - [Implicit Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.2)
+- [Resource Owner Password Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.3)
+- [Client Credentials Grant](https://www.rfc-editor.org/rfc/rfc6749#section-4.4)
 - [Refresh Tokens](https://www.rfc-editor.org/rfc/rfc6749#section-6)
 
 ## Usage

--- a/examples/oak.ts
+++ b/examples/oak.ts
@@ -1,9 +1,13 @@
-import { Application, Router } from "https://deno.land/x/oak@v6.3.0/mod.ts";
+import { Application, Router } from "https://deno.land/x/oak@v11.1.0/mod.ts";
+import {
+  MemoryStore,
+  Session,
+} from "https://deno.land/x/oak_sessions@v4.0.5/mod.ts";
 import { OAuth2Client } from "https://deno.land/x/oauth2_client/mod.ts";
 
 const oauth2Client = new OAuth2Client({
-  clientId: "<your client id>",
-  clientSecret: "<your client secret>",
+  clientId: Deno.env.get("CLIENT_ID")!,
+  clientSecret: Deno.env.get("CLIENT_SECRET")!,
   authorizationEndpointUri: "https://github.com/login/oauth/authorize",
   tokenUri: "https://github.com/login/oauth/access_token",
   redirectUri: "http://localhost:8000/oauth2/callback",
@@ -12,15 +16,44 @@ const oauth2Client = new OAuth2Client({
   },
 });
 
-const router = new Router();
-router.get("/login", (ctx) => {
-  ctx.response.redirect(
-    oauth2Client.code.getAuthorizationUri(),
-  );
+type AppState = {
+  session: Session;
+};
+
+const router = new Router<AppState>();
+router.get("/login", async (ctx) => {
+  // Generate a random state for this login event
+  const state = crypto.randomUUID();
+
+  // Construct the URL for the authorization redirect and get a PKCE codeVerifier
+  const { uri, codeVerifier } = await oauth2Client.code.getAuthorizationUri({
+    state,
+  });
+
+  // Store both the state and codeVerifier in the user session
+  ctx.state.session.flash("state", state);
+  ctx.state.session.flash("codeVerifier", codeVerifier);
+
+  // Redirect the user to the authorization endpoint
+  ctx.response.redirect(uri);
 });
 router.get("/oauth2/callback", async (ctx) => {
+  // Make sure both a state and codeVerifier are present for the user's session
+  const state = ctx.state.session.get("state");
+  if (typeof state !== "string") {
+    throw new Error("invalid state");
+  }
+
+  const codeVerifier = ctx.state.session.get("codeVerifier");
+  if (typeof codeVerifier !== "string") {
+    throw new Error("invalid codeVerifier");
+  }
+
   // Exchange the authorization code for an access token
-  const tokens = await oauth2Client.code.getToken(ctx.request.url);
+  const tokens = await oauth2Client.code.getToken(ctx.request.url, {
+    state,
+    codeVerifier,
+  });
 
   // Use the access token to make an authenticated API request
   const userResponse = await fetch("https://api.github.com/user", {
@@ -33,7 +66,35 @@ router.get("/oauth2/callback", async (ctx) => {
   ctx.response.body = `Hello, ${login}!`;
 });
 
-const app = new Application();
+const app = new Application<AppState>();
+
+// Add a key for signing cookies
+app.keys = ["super-secret-key"];
+
+// Set up the session middleware
+const sessionStore = new MemoryStore();
+app.use(Session.initMiddleware(sessionStore, {
+  cookieSetOptions: {
+    httpOnly: true,
+    sameSite: "lax",
+    // Enable for when running outside of localhost
+    // secure: true,
+    signed: true,
+  },
+  cookieGetOptions: {
+    signed: true,
+  },
+  expireAfterSeconds: 60 * 10,
+}));
+
+// Mount the router
 app.use(router.allowedMethods(), router.routes());
 
-await app.listen({ port: 8000 });
+// Start the app
+const port = 8000;
+app.addEventListener("listen", () => {
+  console.log(
+    `App listening on port ${port}. Navigate to http://localhost:${port}/login to log in!`,
+  );
+});
+await app.listen({ port });

--- a/mod.ts
+++ b/mod.ts
@@ -2,6 +2,7 @@ export type { RequestOptions, Tokens } from "./src/types.ts";
 
 export type {
   AuthorizationResponseError,
+  MissingClientSecretError,
   OAuth2ResponseError,
   TokenResponseError,
 } from "./src/errors.ts";
@@ -11,9 +12,25 @@ export type { OAuth2ClientConfig } from "./src/oauth2_client.ts";
 
 export type {
   AuthorizationCodeGrant,
-  GetTokenOptions,
-  GetUriOptions,
+  AuthorizationCodeTokenOptions,
+  AuthorizationUri,
+  AuthorizationUriOptions,
+  AuthorizationUriWithoutVerifier,
+  AuthorizationUriWithVerifier,
 } from "./src/authorization_code_grant.ts";
+export type {
+  ClientCredentialsGrant,
+  ClientCredentialsTokenOptions,
+} from "./src/client_credentials_grant.ts";
+export type {
+  ImplicitGrant,
+  ImplicitTokenOptions,
+  ImplicitUriOptions,
+} from "./src/implicit_grant.ts";
+export type {
+  ResourceOwnerPasswordCredentialsGrant,
+  ResourceOwnerPasswordCredentialsTokenOptions,
+} from "./src/resource_owner_password_credentials.ts";
 export type {
   RefreshTokenGrant,
   RefreshTokenOptions,

--- a/src/authorization_code_grant.ts
+++ b/src/authorization_code_grant.ts
@@ -30,7 +30,9 @@ export type AuthorizationUriOptions =
   | AuthorizationUriOptionsWithPKCE
   | AuthorizationUriOptionsWithoutPKCE;
 
-export type AuthorizationUriWithoutVerifier = URL;
+export interface AuthorizationUriWithoutVerifier {
+  uri: URL;
+}
 export interface AuthorizationUriWithVerifier {
   uri: URL;
   codeVerifier: string;
@@ -109,7 +111,9 @@ export class AuthorizationCodeGrant extends OAuth2GrantBase {
     }
 
     if (options.disablePkce === true) {
-      return new URL(`?${params}`, this.client.config.authorizationEndpointUri);
+      return {
+        uri: new URL(`?${params}`, this.client.config.authorizationEndpointUri),
+      };
     }
 
     const challenge = await createPkceChallenge();

--- a/src/authorization_code_grant_test.ts
+++ b/src/authorization_code_grant_test.ts
@@ -186,91 +186,92 @@ Deno.test("AuthorizationCodeGrant.getAuthorizationUri uses specified scopes over
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works without additional options with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client().code.getAuthorizationUri({ disablePkce: true }),
+    (await getOAuth2Client().code.getAuthorizationUri({ disablePkce: true }))
+      .uri,
     "https://auth.server/auth?response_type=code&client_id=clientId",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works when passing a single scope with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client().code.getAuthorizationUri({
+    (await getOAuth2Client().code.getAuthorizationUri({
       scope: "singleScope",
       disablePkce: true,
-    }),
+    })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&scope=singleScope",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works when passing multiple scopes with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client().code.getAuthorizationUri({
+    (await getOAuth2Client().code.getAuthorizationUri({
       scope: ["multiple", "scopes"],
       disablePkce: true,
-    }),
+    })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&scope=multiple+scopes",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works when passing a state parameter with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client().code.getAuthorizationUri({
+    (await getOAuth2Client().code.getAuthorizationUri({
       state: "someState",
       disablePkce: true,
-    }),
+    })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&state=someState",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works with redirectUri with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client({
+    (await getOAuth2Client({
       redirectUri: "https://example.app/redirect",
-    }).code.getAuthorizationUri({ disablePkce: true }),
+    }).code.getAuthorizationUri({ disablePkce: true })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fexample.app%2Fredirect",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works with redirectUri and a single scope with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client({
+    (await getOAuth2Client({
       redirectUri: "https://example.app/redirect",
     }).code.getAuthorizationUri({
       scope: "singleScope",
       disablePkce: true,
-    }),
+    })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fexample.app%2Fredirect&scope=singleScope",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri works with redirectUri and multiple scopes with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client({
+    (await getOAuth2Client({
       redirectUri: "https://example.app/redirect",
     }).code.getAuthorizationUri({
       scope: ["multiple", "scopes"],
       disablePkce: true,
-    }),
+    })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&redirect_uri=https%3A%2F%2Fexample.app%2Fredirect&scope=multiple+scopes",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri uses default scopes if no scope was specified with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client({
+    (await getOAuth2Client({
       defaults: { scope: ["default", "scopes"] },
-    }).code.getAuthorizationUri({ disablePkce: true }),
+    }).code.getAuthorizationUri({ disablePkce: true })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&scope=default+scopes",
   );
 });
 
 Deno.test("AuthorizationCodeGrant.getAuthorizationUri uses specified scopes over default scopes with PKCE disabled", async () => {
   assertMatchesUrl(
-    await getOAuth2Client({
+    (await getOAuth2Client({
       defaults: { scope: ["default", "scopes"] },
     }).code.getAuthorizationUri({
       scope: "notDefault",
       disablePkce: true,
-    }),
+    })).uri,
     "https://auth.server/auth?response_type=code&client_id=clientId&scope=notDefault",
   );
 });

--- a/src/client_credentials_grant.ts
+++ b/src/client_credentials_grant.ts
@@ -3,7 +3,7 @@ import { OAuth2GrantBase } from "./grant_base.ts";
 import type { OAuth2Client } from "./oauth2_client.ts";
 import { RequestOptions, Tokens } from "./types.ts";
 
-export interface GetClientCredentialsTokenOptions {
+export interface ClientCredentialsTokenOptions {
   /**
    * Scopes to request with the authorization request.
    *
@@ -30,7 +30,7 @@ export class ClientCredentialsGrant extends OAuth2GrantBase {
    * Uses the clientId and clientSecret to request an access token
    */
   public async getToken(
-    options: GetClientCredentialsTokenOptions = {},
+    options: ClientCredentialsTokenOptions = {},
   ): Promise<Tokens> {
     const request = this.buildTokenRequest(options);
 
@@ -40,7 +40,7 @@ export class ClientCredentialsGrant extends OAuth2GrantBase {
   }
 
   private buildTokenRequest(
-    options: GetClientCredentialsTokenOptions,
+    options: ClientCredentialsTokenOptions,
   ): Request {
     const { clientId, clientSecret } = this.client.config;
     if (typeof clientSecret !== "string") {

--- a/src/client_credentials_grant_test.ts
+++ b/src/client_credentials_grant_test.ts
@@ -3,8 +3,8 @@ import {
   assertEquals,
   assertMatch,
   assertNotMatch,
-  assertThrowsAsync,
-} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+  assertRejects,
+} from "https://deno.land/std@0.161.0/testing/asserts.ts";
 
 import {
   MissingClientSecretError,
@@ -16,7 +16,7 @@ import { getOAuth2Client, mockATResponse } from "./test_utils.ts";
 //#region ClientCredentialsGrant.getToken error paths
 
 Deno.test("ClientCredentialsGrant.getToken throws when no client secret was configured", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () => getOAuth2Client().clientCredentials.getToken(),
     MissingClientSecretError,
     "this grant requires a clientSecret to be set",
@@ -24,7 +24,7 @@ Deno.test("ClientCredentialsGrant.getToken throws when no client secret was conf
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server responded with a Content-Type other than application/json", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -38,7 +38,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server responded with a
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server responded with a correctly formatted error", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -52,7 +52,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server responded with a
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server responded with a 4xx or 5xx and the body doesn't contain an error parameter", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -66,7 +66,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server responded with a
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server's response is not a JSON object", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -77,7 +77,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server's response is no
     TokenResponseError,
     "Invalid token response: body is not a JSON object",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -91,7 +91,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server's response is no
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server's response does not contain a token_type", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -105,7 +105,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server's response does 
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server response's token_type is not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -124,7 +124,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server response's token
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server's response does not contain an access_token", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -138,7 +138,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server's response does 
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server response's access_token is not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -157,7 +157,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server response's acces
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server response's refresh_token property is not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -177,7 +177,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server response's refre
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server response's expires_in property is not a number", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -197,7 +197,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server response's expir
 });
 
 Deno.test("ClientCredentialsGrant.getToken throws if the server response's scope property is not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>

--- a/src/errors_test.ts
+++ b/src/errors_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+} from "https://deno.land/std@0.161.0/testing/asserts.ts";
 import {
   AuthorizationResponseError,
   OAuth2ResponseError,

--- a/src/grant_base_test.ts
+++ b/src/grant_base_test.ts
@@ -1,6 +1,4 @@
-import {
-  assertEquals,
-} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
 
 import { OAuth2Client, OAuth2ClientConfig } from "./oauth2_client.ts";
 import { OAuth2GrantBase } from "./grant_base.ts";

--- a/src/implicit_grant.ts
+++ b/src/implicit_grant.ts
@@ -34,7 +34,7 @@ export interface GetTokenOptions {
    *
    * The option object's state value is ignored when a stateValidator is passed.
    */
-  stateValidator?: (state: string | null) => boolean;
+  stateValidator?: (state: string | null) => Promise<boolean> | boolean;
   /** Request options used when making the access token request. */
   requestOptions?: RequestOptions;
 }
@@ -69,10 +69,10 @@ export class ImplicitGrant extends OAuth2GrantBase {
    * @param authResponseUri The complete URI the user got redirected to by the authorization server after making the authorization request.
    *     Must include the fragment (sometimes also called "hash") of the URL.
    */
-  public getToken(
+  public async getToken(
     authResponseUri: string | URL,
     options: GetTokenOptions = {},
-  ): Tokens {
+  ): Promise<Tokens> {
     const url = authResponseUri instanceof URL
       ? authResponseUri
       : new URL(authResponseUri);
@@ -130,7 +130,7 @@ export class ImplicitGrant extends OAuth2GrantBase {
       tokens.expiresIn = parseInt(expiresInRaw, 10);
     }
 
-    if (stateValidator && !stateValidator(state)) {
+    if (stateValidator && !await stateValidator(state)) {
       if (state === null) {
         throw new AuthorizationResponseError("missing state");
       } else {

--- a/src/implicit_grant.ts
+++ b/src/implicit_grant.ts
@@ -3,7 +3,7 @@ import { OAuth2GrantBase } from "./grant_base.ts";
 import { AuthorizationResponseError, OAuth2ResponseError } from "./errors.ts";
 import type { RequestOptions, Tokens } from "./types.ts";
 
-export interface GetUriOptions {
+export interface ImplicitUriOptions {
   /**
    * State parameter to send along with the authorization request.
    *
@@ -19,7 +19,7 @@ export interface GetUriOptions {
   scope?: string | string[];
 }
 
-export interface GetTokenOptions {
+export interface ImplicitTokenOptions {
   /**
    * The state parameter expected to be returned by the authorization response.
    *
@@ -45,7 +45,7 @@ export class ImplicitGrant extends OAuth2GrantBase {
   }
 
   /** Builds a URI you can redirect a user to to make the authorization request. */
-  public getAuthorizationUri(options: GetUriOptions = {}): URL {
+  public getAuthorizationUri(options: ImplicitUriOptions = {}): URL {
     const params = new URLSearchParams();
     params.set("response_type", "token");
     params.set("client_id", this.client.config.clientId);
@@ -71,7 +71,7 @@ export class ImplicitGrant extends OAuth2GrantBase {
    */
   public async getToken(
     authResponseUri: string | URL,
-    options: GetTokenOptions = {},
+    options: ImplicitTokenOptions = {},
   ): Promise<Tokens> {
     const url = authResponseUri instanceof URL
       ? authResponseUri

--- a/src/oauth2_client.ts
+++ b/src/oauth2_client.ts
@@ -28,7 +28,7 @@ export interface OAuth2ClientConfig {
     /** Default scopes to request unless otherwise specified. */
     scope?: string | string[];
     /** Default state validator to use for validating the authorization response's state value. */
-    stateValidator?: (state: string | null) => boolean;
+    stateValidator?: (state: string | null) => Promise<boolean> | boolean;
   };
 }
 

--- a/src/oauth2_client_test.ts
+++ b/src/oauth2_client_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "https://deno.land/std@0.71.0/testing/asserts.ts";
+import { assert } from "https://deno.land/std@0.161.0/testing/asserts.ts";
 
 import { OAuth2Client } from "./oauth2_client.ts";
 import { AuthorizationCodeGrant } from "./authorization_code_grant.ts";

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -1,0 +1,56 @@
+import { encode } from "https://deno.land/std@0.161.0/encoding/base64.ts";
+
+export interface PkceChallenge {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+}
+
+/**
+ * Encodes the data as a URL-safe variant of Base64
+ * in accordance with https://www.rfc-editor.org/rfc/rfc7636#appendix-A
+ */
+function encodeUrlSafe(data: string | ArrayBuffer): string {
+  return encode(data)
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/** Calculates the SHA256 hash of the given string */
+async function sha256(str: string): Promise<ArrayBuffer> {
+  const bytes = new TextEncoder().encode(str);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return hash;
+}
+
+/** Returns a byte array of the given length, filled with random numbers */
+function getRandomBytes(length: number): ArrayBuffer {
+  const randomBytes = new Uint8Array(length);
+  crypto.getRandomValues(randomBytes);
+  return randomBytes;
+}
+
+/**
+ * Creates a codeChallenge and codeVerifier in accordance with the
+ * Proof Key for Code Exchange (PKCE) {@link https://www.rfc-editor.org/rfc/rfc7636 RFC7636}
+ *
+ * See {@link https://www.rfc-editor.org/rfc/rfc7636#section-4 RFC7636 Section 4}
+ * for a step-by-step explanation of what's happening here.
+ */
+export async function createPkceChallenge(): Promise<PkceChallenge> {
+  const randomBytes = _internals.getRandomBytes(32);
+  const codeVerifier = encodeUrlSafe(randomBytes);
+
+  const hash = await sha256(codeVerifier);
+  const codeChallenge = encodeUrlSafe(hash);
+
+  return {
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: "S256",
+  };
+}
+
+/** @deprecated This should only ever be used for testing */
+export const _internals = { getRandomBytes };

--- a/src/pkce_test.ts
+++ b/src/pkce_test.ts
@@ -1,0 +1,87 @@
+import {
+  assertEquals,
+  assertMatch,
+} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+import {
+  returnsNext,
+  stub,
+} from "https://deno.land/std@0.161.0/testing/mock.ts";
+
+import { _internals as pkceInternals, createPkceChallenge } from "./pkce.ts";
+
+/**
+ * Returns the byte array from the example in https://www.rfc-editor.org/rfc/rfc7636#appendix-B
+ */
+function getExampleBytes(): Uint8Array {
+  return new Uint8Array([
+    116,
+    24,
+    223,
+    180,
+    151,
+    153,
+    224,
+    37,
+    79,
+    250,
+    96,
+    125,
+    216,
+    173,
+    187,
+    186,
+    22,
+    212,
+    37,
+    77,
+    105,
+    214,
+    191,
+    240,
+    91,
+    88,
+    5,
+    88,
+    83,
+    132,
+    141,
+    121,
+  ]);
+}
+
+Deno.test("createPkceChallenge correctly builds a codeChallenge and codeVerifier", async () => {
+  const getRandomBytesStub = stub(
+    pkceInternals,
+    "getRandomBytes",
+    returnsNext([getExampleBytes()]),
+  );
+  try {
+    const { codeVerifier, codeChallenge, codeChallengeMethod } =
+      await createPkceChallenge();
+
+    assertEquals(codeChallengeMethod, "S256");
+    assertEquals(codeVerifier, "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
+    assertEquals(codeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+  } finally {
+    getRandomBytesStub.restore();
+  }
+});
+
+Deno.test("createPkceChallenge returns random base64url encoded codes", async () => {
+  const urlBase64Regex = /^[a-z0-9_-]{43}$/i;
+
+  const verifiers = new Set<string>();
+  const challenges = new Set<string>();
+
+  for (let i = 0; i < 1000; i++) {
+    const { codeVerifier, codeChallenge } = await createPkceChallenge();
+
+    assertEquals(verifiers.has(codeVerifier), false);
+    assertEquals(challenges.has(codeChallenge), false);
+    verifiers.add(codeVerifier);
+    verifiers.add(codeChallenge);
+
+    assertMatch(codeVerifier, urlBase64Regex);
+    assertMatch(codeChallenge, urlBase64Regex);
+  }
+});

--- a/src/refresh_token_grant_test.ts
+++ b/src/refresh_token_grant_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.71.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
 import { getOAuth2Client, mockATResponse } from "./test_utils.ts";
 
 Deno.test("RefreshTokenGrant.refresh works without optional options", async () => {

--- a/src/resource_owner_password_credentials.ts
+++ b/src/resource_owner_password_credentials.ts
@@ -2,7 +2,7 @@ import { OAuth2GrantBase } from "./grant_base.ts";
 import type { OAuth2Client } from "./oauth2_client.ts";
 import type { RequestOptions, Tokens } from "./types.ts";
 
-export interface GetROPCTokenOptions {
+export interface ResourceOwnerPasswordCredentialsTokenOptions {
   /** The resource owner username */
   username: string;
   /** The resource owner password */
@@ -32,7 +32,7 @@ export class ResourceOwnerPasswordCredentialsGrant extends OAuth2GrantBase {
    * Uses the username and password to request an access and optional refresh token
    */
   public async getToken(
-    options: GetROPCTokenOptions,
+    options: ResourceOwnerPasswordCredentialsTokenOptions,
   ): Promise<Tokens> {
     const request = this.buildTokenRequest(options);
 
@@ -41,7 +41,9 @@ export class ResourceOwnerPasswordCredentialsGrant extends OAuth2GrantBase {
     return this.parseTokenResponse(accessTokenResponse);
   }
 
-  private buildTokenRequest(options: GetROPCTokenOptions): Request {
+  private buildTokenRequest(
+    options: ResourceOwnerPasswordCredentialsTokenOptions,
+  ): Request {
     const body: Record<string, string> = {
       "grant_type": "password",
       username: options.username,

--- a/src/resource_owner_password_credentials_test.ts
+++ b/src/resource_owner_password_credentials_test.ts
@@ -3,8 +3,8 @@ import {
   assertEquals,
   assertMatch,
   assertNotMatch,
-  assertThrowsAsync,
-} from "https://deno.land/std@0.71.0/testing/asserts.ts";
+  assertRejects,
+} from "https://deno.land/std@0.161.0/testing/asserts.ts";
 
 import { OAuth2ResponseError, TokenResponseError } from "./errors.ts";
 import { getOAuth2Client, mockATResponse } from "./test_utils.ts";
@@ -12,7 +12,7 @@ import { getOAuth2Client, mockATResponse } from "./test_utils.ts";
 //#region ResourceOwnerPasswordCredentialsGrant.getToken error paths
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server responded with a Content-Type other than application/json", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -25,7 +25,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server responded with a correctly formatted error", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -38,7 +38,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server responded with a 4xx or 5xx and the body doesn't contain an error parameter", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -51,7 +51,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's response is not a JSON object", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -61,7 +61,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's
     TokenResponseError,
     "Invalid token response: body is not a JSON object",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -74,7 +74,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's response does not contain a token_type", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -87,7 +87,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's token_type is not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -105,7 +105,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's response does not contain an access_token", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -118,7 +118,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server's
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's access_token is not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -136,7 +136,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's refresh_token property is present but not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -155,7 +155,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's expires_in property is present but not a number", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>
@@ -174,7 +174,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
 });
 
 Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's scope property is present but not a string", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       mockATResponse(
         () =>


### PR DESCRIPTION
- Updated all tests to use `https://deno.land/std@0.161.0/testing/`
- Replace mock library and use `https://deno.land/std@0.161.0/testing/mock.ts` instead
- Introduce PKCE by default when using the Authorization Code Grant
    - The module automatically generates `code_challenge` and  `code_verifier` values if not using the opt-out option
- Interfaces were renamed to prevent name clashes between grants
- The `stateValidator` callback that's used by both the Implicit and Authorization Code Grants can now return a `Promise<boolean>`, allowing e.g. database calls to be made inside the callback.
- `AuthorizationCodeGrant.getAuthorizationUri` now always returns a `{ uri: URL }` value, plus an additional `codeVerifier: string` when using PKCE
- `AuthorizationCodeGrant.getAuthorizationUri` is now async (to account for both the `stateValidator` and the generation of the PKCE `codeChallenge` being async)
- upgrade GitHub workflow dependencies
    - use `actions/checkout@v3` (instead of v2)
    - use `denoland/setup-deno@v1` (instead of `denolib/setup-deno@v1`)
    - remove `--unstable` flags from deno commands that no longer require them