### PR TITLE
Allow Array of strings for scope in token response

### DIFF
--- a/src/authorization_code_grant_test.ts
+++ b/src/authorization_code_grant_test.ts
@@ -593,7 +593,7 @@ Deno.test("AuthorizationCodeGrant.getToken throws if the server response's expir
   );
 });
 
-Deno.test("AuthorizationCodeGrant.getToken throws if the server response's scope property is not a string", async () => {
+Deno.test("AuthorizationCodeGrant.getToken throws if the server response's scope property is not a string or array of strings", async () => {
   await assertRejects(
     () =>
       mockATResponse(
@@ -605,12 +605,30 @@ Deno.test("AuthorizationCodeGrant.getToken throws if the server response's scope
           body: {
             access_token: "at",
             token_type: "tt",
-            scope: ["scope1", "scope2"] as any,
+            scope: 1 as any,
           },
         },
       ),
     TokenResponseError,
     "Invalid token response: scope is not a string",
+  );
+  await assertRejects(
+    () =>
+      mockATResponse(
+        () =>
+          getOAuth2Client().code.getToken(buildAccessTokenCallback({
+            params: { code: "authCode" },
+          })),
+        {
+          body: {
+            access_token: "at",
+            token_type: "tt",
+            scope: ["scope1", 2] as any,
+          },
+        },
+      ),
+    TokenResponseError,
+    "Invalid token response: scopes are not a string",
   );
 });
 

--- a/src/client_credentials_grant_test.ts
+++ b/src/client_credentials_grant_test.ts
@@ -196,7 +196,7 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server response's expir
   );
 });
 
-Deno.test("ClientCredentialsGrant.getToken throws if the server response's scope property is not a string", async () => {
+Deno.test("ClientCredentialsGrant.getToken throws if the server response's scope property is not a string or array of strings", async () => {
   await assertRejects(
     () =>
       mockATResponse(
@@ -207,12 +207,29 @@ Deno.test("ClientCredentialsGrant.getToken throws if the server response's scope
           body: {
             access_token: "at",
             token_type: "tt",
-            scope: ["scope1", "scope2"] as any,
+            scope: 1 as any,
           },
         },
       ),
     TokenResponseError,
     "Invalid token response: scope is not a string",
+  );
+  await assertRejects(
+    () =>
+      mockATResponse(
+        () =>
+          getOAuth2Client({ clientSecret: "secret" }).clientCredentials
+            .getToken(),
+        {
+          body: {
+            access_token: "at",
+            token_type: "tt",
+            scope: ["scope1", 2] as any,
+          },
+        },
+      ),
+    TokenResponseError,
+    "Invalid token response: scopes are not a string",
   );
 });
 

--- a/src/grant_base.ts
+++ b/src/grant_base.ts
@@ -119,9 +119,21 @@ export abstract class OAuth2GrantBase {
         response,
       );
     }
-    if (body.scope !== undefined && typeof body.scope !== "string") {
+    if (
+      body.scope !== undefined && typeof body.scope !== "string" &&
+      !Array.isArray(body.scope)
+    ) {
       throw new TokenResponseError(
         "scope is not a string",
+        response,
+      );
+    }
+    if (
+      Array.isArray(body.scope) &&
+      body.scope.some((value) => typeof value !== "string")
+    ) {
+      throw new TokenResponseError(
+        "scopes are not a string",
         response,
       );
     }
@@ -138,7 +150,11 @@ export abstract class OAuth2GrantBase {
       tokens.expiresIn = body.expires_in;
     }
     if (body.scope) {
-      tokens.scope = body.scope.split(" ");
+      if (typeof body.scope === "string") {
+        tokens.scope = body.scope.split(" ");
+      } else {
+        tokens.scope = body.scope;
+      }
     }
 
     return tokens;

--- a/src/grant_base.ts
+++ b/src/grant_base.ts
@@ -7,7 +7,7 @@ interface AccessTokenResponse {
   "token_type": string;
   "expires_in"?: number;
   "refresh_token"?: string;
-  scope?: string;
+  scope?: string | string[];
 }
 
 /**

--- a/src/resource_owner_password_credentials_test.ts
+++ b/src/resource_owner_password_credentials_test.ts
@@ -173,7 +173,7 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
   );
 });
 
-Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's scope property is present but not a string", async () => {
+Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server response's scope property is present but not a string or array of strings", async () => {
   await assertRejects(
     () =>
       mockATResponse(
@@ -183,12 +183,28 @@ Deno.test("ResourceOwnerPasswordCredentialsGrant.getToken throws if the server r
           body: {
             access_token: "at",
             token_type: "tt",
-            scope: ["scope1", "scope2"] as any,
+            scope: 1 as any,
           },
         },
       ),
     TokenResponseError,
     "Invalid token response: scope is not a string",
+  );
+  await assertRejects(
+    () =>
+      mockATResponse(
+        () =>
+          getOAuth2Client().ropc.getToken({ username: "un", password: "pw" }),
+        {
+          body: {
+            access_token: "at",
+            token_type: "tt",
+            scope: ["scope1", 2] as any,
+          },
+        },
+      ),
+    TokenResponseError,
+    "Invalid token response: scopes are not a string",
   );
 });
 

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -42,7 +42,7 @@ interface AccessTokenResponse {
   "token_type": string;
   "expires_in"?: number;
   "refresh_token"?: string;
-  scope?: string;
+  scope?: string | string[];
 }
 
 interface MockAccessTokenResponse {


### PR DESCRIPTION
## Motivation
I would like to use this library to connect to an OAuth provider (Twitch in my case) which returns scopes as an array of strings rather than a space-separated string. These changes update the token response parser to allow this case.

## Testing
Updated tests to reflect this change

Tested using [Deno KV OAuth](https://github.com/denoland/deno_kv_oauth)'s demo test. This can be seen on [my fork](https://github.com/mitchwadair/deno_kv_oauth/blob/twitch/src/providers/twitch.ts) of the library, when switching `deps.ts` to point to my changes here.
![image](https://github.com/cmd-johnson/deno-oauth2-client/assets/25411268/ba384d1b-c98c-44b2-8d05-8f58bab0a7c9)

Let me know if there's anything I missed or need to change 👍 