### PR TITLE
chore: treat imports as local imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "https://deno.land/x/oauth2_client/": "./"
+  }
+}


### PR DESCRIPTION
This change makes the linter happy by tricking it into thinking that imports from `https://deno.land/x/oauth2_client/` are local imports. This means that examples use the most up-to-date code.