### PR TITLE
chore: upgrade to `std@0.203.0`

### DIFF
--- a/examples/http.ts
+++ b/examples/http.ts
@@ -1,10 +1,9 @@
-import { serve } from "https://deno.land/std@0.161.0/http/server.ts";
 import {
   Cookie,
   deleteCookie,
   getCookies,
   setCookie,
-} from "https://deno.land/std@0.161.0/http/cookie.ts";
+} from "https://deno.land/std@0.203.0/http/cookie.ts";
 import { OAuth2Client } from "https://deno.land/x/oauth2_client/mod.ts";
 
 const oauth2Client = new OAuth2Client({
@@ -89,4 +88,4 @@ async function handleCallback(req: Request): Promise<Response> {
 }
 
 // Start the app
-serve(handler, { port: 8000 });
+Deno.serve({ port: 8000 }, handler);

--- a/src/authorization_code_grant_test.ts
+++ b/src/authorization_code_grant_test.ts
@@ -4,13 +4,13 @@ import {
   assertMatch,
   assertNotMatch,
   assertRejects,
-} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/assert/mod.ts";
 import {
   assertSpyCall,
   assertSpyCallAsync,
   assertSpyCalls,
   spy,
-} from "https://deno.land/std@0.161.0/testing/mock.ts";
+} from "https://deno.land/std@0.203.0/testing/mock.ts";
 
 import {
   AuthorizationResponseError,

--- a/src/client_credentials_grant_test.ts
+++ b/src/client_credentials_grant_test.ts
@@ -4,7 +4,7 @@ import {
   assertMatch,
   assertNotMatch,
   assertRejects,
-} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/assert/mod.ts";
 
 import {
   MissingClientSecretError,

--- a/src/errors_test.ts
+++ b/src/errors_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/assert/mod.ts";
 import {
   AuthorizationResponseError,
   OAuth2ResponseError,

--- a/src/grant_base_test.ts
+++ b/src/grant_base_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
 
 import { OAuth2Client, OAuth2ClientConfig } from "./oauth2_client.ts";
 import { OAuth2GrantBase } from "./grant_base.ts";

--- a/src/implicit_grant_test.ts
+++ b/src/implicit_grant_test.ts
@@ -2,13 +2,13 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/assert/mod.ts";
 import {
   assertSpyCall,
   assertSpyCallAsync,
   assertSpyCalls,
   spy,
-} from "https://deno.land/std@0.161.0/testing/mock.ts";
+} from "https://deno.land/std@0.203.0/testing/mock.ts";
 
 import { AuthorizationResponseError, OAuth2ResponseError } from "./errors.ts";
 import {

--- a/src/oauth2_client_test.ts
+++ b/src/oauth2_client_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "https://deno.land/std@0.161.0/testing/asserts.ts";
+import { assert } from "https://deno.land/std@0.203.0/assert/assert.ts";
 
 import { OAuth2Client } from "./oauth2_client.ts";
 import { AuthorizationCodeGrant } from "./authorization_code_grant.ts";

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -1,4 +1,4 @@
-import { encode } from "https://deno.land/std@0.161.0/encoding/base64.ts";
+import { encodeBase64 } from "https://deno.land/std@0.203.0/encoding/base64.ts";
 
 export interface PkceChallenge {
   codeVerifier: string;
@@ -11,7 +11,7 @@ export interface PkceChallenge {
  * in accordance with https://www.rfc-editor.org/rfc/rfc7636#appendix-A
  */
 function encodeUrlSafe(data: string | ArrayBuffer): string {
-  return encode(data)
+  return encodeBase64(data)
     .replace(/=/g, "")
     .replace(/\+/g, "-")
     .replace(/\//g, "_");

--- a/src/pkce_test.ts
+++ b/src/pkce_test.ts
@@ -1,11 +1,11 @@
 import {
   assertEquals,
   assertMatch,
-} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/assert/mod.ts";
 import {
   returnsNext,
   stub,
-} from "https://deno.land/std@0.161.0/testing/mock.ts";
+} from "https://deno.land/std@0.203.0/testing/mock.ts";
 
 import { _internals as pkceInternals, createPkceChallenge } from "./pkce.ts";
 

--- a/src/refresh_token_grant_test.ts
+++ b/src/refresh_token_grant_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
 import { getOAuth2Client, mockATResponse } from "./test_utils.ts";
 
 Deno.test("RefreshTokenGrant.refresh works without optional options", async () => {

--- a/src/resource_owner_password_credentials_test.ts
+++ b/src/resource_owner_password_credentials_test.ts
@@ -4,7 +4,7 @@ import {
   assertMatch,
   assertNotMatch,
   assertRejects,
-} from "https://deno.land/std@0.161.0/testing/asserts.ts";
+} from "https://deno.land/std@0.203.0/assert/mod.ts";
 
 import { OAuth2ResponseError, TokenResponseError } from "./errors.ts";
 import { getOAuth2Client, mockATResponse } from "./test_utils.ts";

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -1,10 +1,10 @@
 // deno-lint-ignore-file camelcase
 
-import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.203.0/assert/assert_equals.ts";
 import {
   returnsNext,
   stub,
-} from "https://deno.land/std@0.161.0/testing/mock.ts";
+} from "https://deno.land/std@0.203.0/testing/mock.ts";
 import { OAuth2Client, OAuth2ClientConfig } from "./oauth2_client.ts";
 import { Tokens } from "./types.ts";
 


### PR DESCRIPTION
Deprecations have been accounted for, and `Deno.serve()` is now in use.