### PR TITLE
chore: add `ok` task and simplify CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use Unix line endings in all text files.
+* text=auto eol=lf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,21 +34,6 @@ jobs:
       - name: Print Coverage
         run: deno coverage cov_profile
 
-  validateBundle:
-    strategy:
-      matrix:
-        deno: ["v1.x", "canary"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Setup repo
-        uses: actions/checkout@v3
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: ${{ matrix.deno }}
-
       - name: Bundle code
         run: deno bundle mod.ts > mod.bundle.js
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,32 +28,11 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }} # tests across multiple Deno versions
 
-      - name: Check types
-        run: deno task check:types
-
-      - name: Run Tests
-        run: deno task test --coverage=cov_profile
+      - name: Check formatting, linting, types and run tests
+        run: deno task ok --coverage=cov_profile
 
       - name: Print Coverage
         run: deno coverage cov_profile
-
-  lint:
-    strategy:
-      matrix:
-        deno: ["v1.x", "canary"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Setup repo
-        uses: actions/checkout@v3
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: ${{ matrix.deno }}
-
-      - name: Run lint
-        run: deno lint
 
   validateBundle:
     strategy:

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,7 @@
   },
   "tasks": {
     "check:types": "deno check **/*.ts",
-    "test": "deno test --parallel --trace-ops --doc"
+    "test": "deno test --parallel --trace-ops --doc",
+    "ok": "deno fmt --check && deno lint && deno task check:types && deno task test"
   }
 }


### PR DESCRIPTION
Running `deno task ok` is essentially the only command a contributor needs. It ensures everything is ok and increases the chances that CI will pass as both the local machine and CI use the same command. This has worked great every time I've added it to a codebase.