### PR TITLE
Strava support

### DIFF
--- a/examples/strava.ts
+++ b/examples/strava.ts
@@ -1,0 +1,92 @@
+import {
+  Cookie,
+  deleteCookie,
+  getCookies,
+  setCookie,
+} from "https://deno.land/std@0.203.0/http/cookie.ts";
+import { OAuth2Client } from "https://deno.land/x/oauth2_client/mod.ts";
+
+const oauth2Client = new OAuth2Client({
+  clientId: Deno.env.get("CLIENT_ID")!,
+  clientSecret: Deno.env.get("CLIENT_SECRET")!,
+  authorizationEndpointUri: "https://www.strava.com/oauth/authorize",
+  tokenUri: "https://www.strava.com/oauth/token",
+  redirectUri: "http://localhost:8000/oauth2/callback",
+  defaults: {
+    scope: "",
+  },
+});
+
+/** This is where we'll store our state and PKCE codeVerifiers */
+const loginStates = new Map<string, { state: string; codeVerifier: string }>();
+/** The name we'll use for the session cookie */
+const cookieName = "session";
+
+/** Handles incoming HTTP requests */
+function handler(req: Request): Promise<Response> | Response {
+  const url = new URL(req.url);
+  const path = url.pathname;
+
+  switch (path) {
+    case "/login":
+      return redirectToAuthEndpoint();
+    case "/oauth2/callback":
+      return handleCallback(req);
+    default:
+      return new Response("Not Found", { status: 404 });
+  }
+}
+
+async function redirectToAuthEndpoint(): Promise<Response> {
+  // Generate a random state
+  const state = crypto.randomUUID();
+
+  const { uri, codeVerifier } = await oauth2Client.code.getAuthorizationUri({
+    state,
+  });
+
+  // Associate the state and PKCE codeVerifier with a session cookie
+  const sessionId = crypto.randomUUID();
+  loginStates.set(sessionId, { state, codeVerifier });
+  const sessionCookie: Cookie = {
+    name: cookieName,
+    value: sessionId,
+    httpOnly: true,
+    sameSite: "Lax",
+  };
+  const headers = new Headers({ Location: uri.toString() });
+  setCookie(headers, sessionCookie);
+
+  // Redirect to the authorization endpoint
+  return new Response(null, { status: 302, headers });
+}
+
+async function handleCallback(req: Request): Promise<Response> {
+  // Load the state and PKCE codeVerifier associated with the session
+  const sessionCookie = getCookies(req.headers)[cookieName];
+  const loginState = sessionCookie && loginStates.get(sessionCookie);
+  if (!loginState) {
+    throw new Error("invalid session");
+  }
+  loginStates.delete(sessionCookie);
+
+  // Exchange the authorization code for an access token
+  console.log(req.url);
+  const tokens = await oauth2Client.code.getToken(req.url, loginState);
+
+  // Use the access token to make an authenticated API request
+  const userResponse = await fetch("https://www.strava.com/api/v3/athlete", {
+    headers: {
+      Authorization: `Bearer ${tokens.accessToken}`,
+    },
+  });
+  const { firstname } = await userResponse.json();
+
+  // Clear the session cookie since we don't need it anymore
+  const headers = new Headers();
+  deleteCookie(headers, cookieName);
+  return new Response(`Hello, ${firstname}!`);
+}
+
+// Start the app
+Deno.serve({ port: 8000 }, handler);

--- a/examples/strava.ts
+++ b/examples/strava.ts
@@ -71,7 +71,6 @@ async function handleCallback(req: Request): Promise<Response> {
   loginStates.delete(sessionCookie);
 
   // Exchange the authorization code for an access token
-  console.log(req.url);
   const tokens = await oauth2Client.code.getToken(req.url, loginState);
 
   // Use the access token to make an authenticated API request

--- a/src/authorization_code_grant.ts
+++ b/src/authorization_code_grant.ts
@@ -230,13 +230,19 @@ export class AuthorizationCodeGrant extends OAuth2GrantBase {
       body.redirect_uri = this.client.config.redirectUri;
     }
 
+    if (typeof this.client.config.clientId === "string") {
+      body.client_id = this.client.config.clientId;
+    }
+
     if (typeof this.client.config.clientSecret === "string") {
-      // We have a client secret, authenticate using HTTP Basic Auth as described in RFC6749 Section 2.3.1.
+      // Some resource servers require the client secret to be sent in the
+      // request body, and some require it as Basic Auth. We supply both.
+      body.client_secret = this.client.config.clientSecret;
+
+      // We have a client secret, authenticate using HTTP Basic Auth as
+      // described in RFC6749 Section 2.3.1.
       const { clientId, clientSecret } = this.client.config;
       headers.Authorization = `Basic ${btoa(`${clientId}:${clientSecret}`)}`;
-    } else {
-      // This appears to be a public client, include the client ID along in the body
-      body.client_id = this.client.config.clientId;
     }
 
     return this.buildRequest(this.client.config.tokenUri, {

--- a/src/authorization_code_grant_test.ts
+++ b/src/authorization_code_grant_test.ts
@@ -722,7 +722,7 @@ Deno.test("AuthorizationCodeGrant.getToken correctly adds the redirectUri to the
   );
 });
 
-Deno.test("AuthorizationCodeGrant.getToken sends the clientId as form parameter if no clientSecret is set", async () => {
+Deno.test("AuthorizationCodeGrant.getToken sends the clientId as form parameter", async () => {
   const { request } = await mockATResponse(
     () =>
       getOAuth2Client().code.getToken(buildAccessTokenCallback({
@@ -733,7 +733,21 @@ Deno.test("AuthorizationCodeGrant.getToken sends the clientId as form parameter 
     (await request.formData()).get("client_id"),
     "clientId",
   );
-  assertEquals(request.headers.get("Authorization"), null);
+});
+
+Deno.test("AuthorizationCodeGrant.getToken sends the clientSecret as form parameter if it is set", async () => {
+  const { request } = await mockATResponse(
+    () =>
+      getOAuth2Client({ clientSecret: "super-secret" }).code.getToken(
+        buildAccessTokenCallback({
+          params: { code: "authCode" },
+        }),
+      ),
+  );
+  assertEquals(
+    (await request.formData()).get("client_secret"),
+    "super-secret",
+  );
 });
 
 Deno.test("AuthorizationCodeGrant.getToken sends the correct Authorization header if the clientSecret is set", async () => {
@@ -749,7 +763,18 @@ Deno.test("AuthorizationCodeGrant.getToken sends the correct Authorization heade
     request.headers.get("Authorization"),
     "Basic Y2xpZW50SWQ6c3VwZXItc2VjcmV0",
   );
-  assertEquals((await request.formData()).get("client_id"), null);
+});
+
+Deno.test("AuthorizationCodeGrant.getToken sends no Authorization header if clientSecret is not set", async () => {
+  const { request } = await mockATResponse(
+    () =>
+      getOAuth2Client().code.getToken(
+        buildAccessTokenCallback({
+          params: { code: "authCode" },
+        }),
+      ),
+  );
+  assertEquals(request.headers.get("Authorization"), null);
 });
 
 Deno.test("AuthorizationCodeGrant.getToken uses the default request options", async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 interface ErrorResponseParams {
-  error: string;
+  error?: string;
+  errors?: object[];
   "error_description"?: string;
   "error_uri"?: string;
   state?: string;
@@ -14,7 +15,8 @@ export class MissingClientSecretError extends Error {
 
 /** Generic error returned by an OAuth 2.0 authorization server. */
 export class OAuth2ResponseError extends Error {
-  public readonly error: string;
+  public readonly error?: string;
+  public readonly errors?: object[];
   public readonly errorDescription?: string;
   public readonly errorUri?: string;
   public readonly state?: string;
@@ -23,6 +25,7 @@ export class OAuth2ResponseError extends Error {
     super(response.error_description || response.error);
 
     this.error = response.error;
+    this.errors = response.errors;
     this.errorDescription = response.error_description;
     this.errorUri = response.error_uri;
     this.state = response.state;

--- a/src/grant_base.ts
+++ b/src/grant_base.ts
@@ -150,8 +150,8 @@ export abstract class OAuth2GrantBase {
   ): Promise<OAuth2ResponseError | TokenResponseError> {
     try {
       const body = await response.json();
-      if (typeof body.error !== "string") {
-        throw new TypeError("body should contain an error");
+      if (typeof body.error !== "string" && !Array.isArray(body.errors)) {
+        throw new TypeError("body should contain one or more errors");
       }
       return new OAuth2ResponseError(body);
     } catch {


### PR DESCRIPTION
Authentication against strava.com needed the following changes:

- Support an `errors` array in the responses, not just an `error` string.
- Always include client id and secret as form data, even if Basic Auth is used.